### PR TITLE
fix docker build by installing deps without cd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:18
+
+WORKDIR /app
+
+# Install backend deps
+COPY backend/package*.json backend/
+RUN npm install --prefix backend
+
+# Install frontend deps
+COPY frontend/package*.json frontend/
+RUN npm install --prefix frontend
+
+# Copy the rest of the code
+COPY . .
+
+CMD ["npm", "--prefix", "backend", "start"]

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,1 @@
+console.log('Backend server');

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"No tests\""
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  app:
+    build: .
+    command: npm --prefix backend start

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "echo frontend start",
+    "test": "echo 'No frontend tests'"
+  }
+}


### PR DESCRIPTION
## Summary
- install backend and frontend dependencies without using `cd`
- add minimal backend/frontend package files and docker-compose for testing

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b0a37ece4c83259377b123afb101ab