### PR TITLE
Keep backend server running with Express

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ RUN npm install --prefix frontend
 # Copy the rest of the code
 COPY . .
 
+EXPOSE 3000
 CMD ["npm", "--prefix", "backend", "start"]

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,1 +1,12 @@
-console.log('Backend server');
+const express = require('express');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  res.send('Backend server');
+});
+
+app.listen(PORT, () => {
+  console.log(`Backend server listening on port ${PORT}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,5 +5,8 @@
   "scripts": {
     "start": "node index.js",
     "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "express": "^4.18.2"
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,3 +2,5 @@ services:
   app:
     build: .
     command: npm --prefix backend start
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
## Summary
- add Express-based HTTP server
- expose backend port 3000 in Dockerfile and docker-compose
- declare Express dependency in backend package.json

## Testing
- `npm test --prefix backend`
- `npm install --prefix backend` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a536c4588325a7724432d1b53559