### PR TITLE
Add basic frontend and upload endpoint

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,10 +1,21 @@
 const express = require('express');
+const path = require('path');
+const multer = require('multer');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-app.get('/', (req, res) => {
-  res.send('Backend server');
+// Serve static frontend files
+app.use(express.static(path.join(__dirname, '../frontend')));
+
+// Configure file uploads
+const upload = multer({ dest: path.join(__dirname, 'uploads') });
+
+// Handle form submissions
+app.post('/entries', upload.single('photo'), (req, res) => {
+  const { odometer, tripOdometer } = req.body;
+  const photo = req.file ? req.file.filename : null;
+  res.json({ message: 'Entry received', odometer, tripOdometer, photo });
 });
 
 app.listen(PORT, () => {

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "test": "echo \"No tests\""
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "multer": "^1.4.5-lts.1"
   }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fuel Logger</title>
+</head>
+<body>
+  <h1>Fuel Logger Entry</h1>
+  <form action="/entries" method="POST" enctype="multipart/form-data">
+    <div>
+      <label for="odometer">Odometer:</label>
+      <input type="number" id="odometer" name="odometer" required />
+    </div>
+    <div>
+      <label for="tripOdometer">Trip Odometer:</label>
+      <input type="number" id="tripOdometer" name="tripOdometer" required />
+    </div>
+    <div>
+      <label for="photo">Photo:</label>
+      <input type="file" id="photo" name="photo" accept="image/*" />
+    </div>
+    <button type="submit">Submit</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve static frontend and handle image uploads with Express + Multer
- add HTML form to submit odometer, trip odometer, and photo
- track upload directory and add Multer dependency

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`
- `npm --prefix backend start` *(fails: Cannot find module 'multer')*

------
https://chatgpt.com/codex/tasks/task_e_68b1b6b75280832583d04f7b1f5759b3