### PR TITLE
Add OpenAI receipt parsing service

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "openai": "^4.0.0"
   }
 }

--- a/backend/services/openai.js
+++ b/backend/services/openai.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const OpenAI = require('openai');
+
+const client = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+async function callModel(model, imageBase64) {
+  return client.responses.parse({
+    model,
+    input: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'input_text',
+            text: 'Extract litres, price per litre, and total cost from this fuel receipt image. Respond with JSON matching the given schema.'
+          },
+          { type: 'input_image', image_base64: imageBase64 }
+        ]
+      }
+    ],
+    schema: {
+      type: 'object',
+      properties: {
+        litres: { type: 'number' },
+        price_per_litre: { type: 'number' },
+        total_cost: { type: 'number' }
+      },
+      required: ['litres', 'price_per_litre', 'total_cost']
+    }
+  });
+}
+
+async function parseReceipt(imagePath) {
+  try {
+    const imageBase64 = fs.readFileSync(imagePath, { encoding: 'base64' });
+    let response;
+    try {
+      response = await callModel('gpt5-nano', imageBase64);
+    } catch (err) {
+      response = await callModel('gpt-4.1-mini', imageBase64);
+    }
+    const parsed = response.output?.[0]?.content?.[0]?.parsed;
+    if (
+      !parsed ||
+      typeof parsed.litres !== 'number' ||
+      typeof parsed.price_per_litre !== 'number' ||
+      typeof parsed.total_cost !== 'number'
+    ) {
+      throw new Error('Parsing failed: missing numeric fields in model response.');
+    }
+    return parsed;
+  } catch (error) {
+    throw new Error(`Failed to parse receipt: ${error.message}`);
+  }
+}
+
+module.exports = { parseReceipt };


### PR DESCRIPTION
## Summary
- add OpenAI dependency to backend
- implement parseReceipt to read receipt images using gpt5-nano with gpt-4.1-mini fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1baf4a7c4832590d90819228eff89