### PR TITLE
feat: add Google Sheets integration

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1",
-    "openai": "^4.0.0"
+    "openai": "^4.0.0",
+    "googleapis": "^131.0.0"
   }
 }

--- a/backend/services/googleSheets.js
+++ b/backend/services/googleSheets.js
@@ -1,0 +1,38 @@
+const { google } = require('googleapis');
+
+const auth = new google.auth.JWT(
+  process.env.GOOGLE_CLIENT_EMAIL,
+  null,
+  (process.env.GOOGLE_PRIVATE_KEY || '').replace(/\\n/g, '\n'),
+  ['https://www.googleapis.com/auth/spreadsheets']
+);
+
+const sheets = google.sheets({ version: 'v4', auth });
+
+async function appendFuelRow({
+  odometer,
+  trip_odometer,
+  litres,
+  price_per_litre,
+  total_cost,
+  timestamp
+}) {
+  const values = [[
+    odometer,
+    trip_odometer,
+    litres,
+    price_per_litre,
+    total_cost,
+    timestamp
+  ]];
+
+  await sheets.spreadsheets.values.append({
+    spreadsheetId: process.env.GOOGLE_SHEET_ID,
+    range: 'Sheet1!A:F',
+    valueInputOption: 'USER_ENTERED',
+    requestBody: { values }
+  });
+}
+
+module.exports = { appendFuelRow };
+


### PR DESCRIPTION
## Summary
- add googleapis dependency for Google Sheets API access
- implement Google Sheets service to append fuel entries

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1c4a88efc832597082c91b29fe77d