### PR TITLE
fix: add missing dotenv dependency

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,9 +7,10 @@
     "test": "echo \"No tests\""
   },
   "dependencies": {
+    "dotenv": "^16.4.5",
     "express": "^4.18.2",
+    "googleapis": "^131.0.0",
     "multer": "^1.4.5-lts.1",
-    "openai": "^4.0.0",
-    "googleapis": "^131.0.0"
+    "openai": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `dotenv` to backend dependencies so environment variables load at runtime

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b1e65f33bc8325a0140fc0d843fb2e