### PR TITLE
refactor: update Responses API parameter

### DIFF
--- a/backend/services/openai.js
+++ b/backend/services/openai.js
@@ -20,18 +20,20 @@ async function callModel(model, imageBase64) {
         ]
       }
     ],
-    response_format: {
-      type: 'json_schema',
-      json_schema: {
-        name: 'FuelReceipt',
-        schema: {
-          type: 'object',
-          properties: {
-            litres: { type: 'number' },
-            price_per_litre: { type: 'number' },
-            total_cost: { type: 'number' }
-          },
-          required: ['litres', 'price_per_litre', 'total_cost']
+    text: {
+      format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'FuelReceipt',
+          schema: {
+            type: 'object',
+            properties: {
+              litres: { type: 'number' },
+              price_per_litre: { type: 'number' },
+              total_cost: { type: 'number' }
+            },
+            required: ['litres', 'price_per_litre', 'total_cost']
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- refactor callModel to use `text.format` for structured JSON response

## Testing
- `cd backend && npm test && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68b1ea310cf08325b231cff4fe52a12a