### PR TITLE
Handle base64 receipt images with image_url

### DIFF
--- a/backend/services/openai.js
+++ b/backend/services/openai.js
@@ -16,7 +16,10 @@ async function callModel(model, imageBase64) {
             type: 'input_text',
             text: 'Extract litres, price per litre, and total cost from this fuel receipt image.'
           },
-          { type: 'input_image', image_base64: imageBase64, mime_type: 'image/jpeg' }
+          {
+            type: 'input_image',
+            image_url: { url: `data:image/jpeg;base64,${imageBase64}` }
+          }
         ]
       }
     ],


### PR DESCRIPTION
## Summary
- send receipt images to OpenAI using `image_url` data URLs instead of unsupported `image_base64`

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1f61ae0808325b0d8f1829d4ea588