### PR TITLE
fix: send image_url as string

### DIFF
--- a/backend/services/openai.js
+++ b/backend/services/openai.js
@@ -18,7 +18,7 @@ async function callModel(model, imageBase64) {
           },
           {
             type: 'input_image',
-            image_url: { url: `data:image/jpeg;base64,${imageBase64}` }
+            image_url: `data:image/jpeg;base64,${imageBase64}`
           }
         ]
       }


### PR DESCRIPTION
## Summary
- pass `image_url` as a string when calling OpenAI so API receives proper format

## Testing
- `cd backend && npm test && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68b1f702e310832596bef4f6f608059b