### PR TITLE
Fix OpenAI request format to include text format name

### DIFF
--- a/backend/services/openai.js
+++ b/backend/services/openai.js
@@ -26,17 +26,15 @@ async function callModel(model, imageBase64) {
     text: {
       format: {
         type: 'json_schema',
-        json_schema: {
-          name: 'FuelReceipt',
-          schema: {
-            type: 'object',
-            properties: {
-              litres: { type: 'number' },
-              price_per_litre: { type: 'number' },
-              total_cost: { type: 'number' }
-            },
-            required: ['litres', 'price_per_litre', 'total_cost']
-          }
+        name: 'FuelReceipt',
+        schema: {
+          type: 'object',
+          properties: {
+            litres: { type: 'number' },
+            price_per_litre: { type: 'number' },
+            total_cost: { type: 'number' }
+          },
+          required: ['litres', 'price_per_litre', 'total_cost']
         }
       }
     }


### PR DESCRIPTION
## Summary
- use `name` and `schema` fields directly under `text.format` when calling OpenAI so the API request is valid

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68b496c5a8f88325bc4868741bea661c