### PR TITLE
Add required additionalProperties flag to OpenAI schema

### DIFF
--- a/backend/services/openai.js
+++ b/backend/services/openai.js
@@ -34,7 +34,8 @@ async function callModel(model, imageBase64) {
             price_per_litre: { type: 'number' },
             total_cost: { type: 'number' }
           },
-          required: ['litres', 'price_per_litre', 'total_cost']
+          required: ['litres', 'price_per_litre', 'total_cost'],
+          additionalProperties: false
         }
       }
     }


### PR DESCRIPTION
## Summary
- specify `additionalProperties: false` in FuelReceipt JSON schema to satisfy API validation

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b497b971e88325981e6c51d6127974