### PR TITLE
Align sheet columns with expected order

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The server hosts the static frontend and exposes a `POST /entries` endpoint for 
 2. `multer` stores the upload on disk.
 3. `parseReceipt` (using OpenAI) extracts `litres`, `price_per_litre`, and `total_cost` from the image.
 4. `appendFuelRow` appends the parsed data to the configured Google Sheet.
+   Rows are written in the following column order:
+   Date, Station, Litres, Price/L, Total Cost, GST, Odometer, Trip Odometer.
 
 ## Google API Setup
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -29,12 +29,14 @@ app.post('/entries', upload.single('photo'), async (req, res) => {
     const parsed = await parseReceipt(imagePath);
 
     await appendFuelRow({
-      odometer,
-      trip_odometer: tripOdometer,
+      timestamp: new Date().toISOString(),
+      station: '',
       litres: parsed.litres,
       price_per_litre: parsed.price_per_litre,
       total_cost: parsed.total_cost,
-      timestamp: new Date().toISOString()
+      gst: '',
+      odometer,
+      trip_odometer: tripOdometer
     });
 
     res.json({

--- a/backend/services/googleSheets.js
+++ b/backend/services/googleSheets.js
@@ -10,25 +10,29 @@ const auth = new google.auth.JWT(
 const sheets = google.sheets({ version: 'v4', auth });
 
 async function appendFuelRow({
-  odometer,
-  trip_odometer,
+  timestamp,
+  station = '',
   litres,
   price_per_litre,
   total_cost,
-  timestamp
+  gst = '',
+  odometer,
+  trip_odometer
 }) {
   const values = [[
-    odometer,
-    trip_odometer,
+    timestamp,
+    station,
     litres,
     price_per_litre,
     total_cost,
-    timestamp
+    gst,
+    odometer,
+    trip_odometer
   ]];
 
   await sheets.spreadsheets.values.append({
     spreadsheetId: process.env.GOOGLE_SHEET_ID,
-    range: 'Sheet1!A:F',
+    range: 'Sheet1!A:H',
     valueInputOption: 'USER_ENTERED',
     requestBody: { values }
   });


### PR DESCRIPTION
## Summary
- Correct Google Sheets append logic to match Date → Station → Litres → Price/L → Total Cost → GST → Odometer → Trip Odometer
- Pass placeholder values for missing Station and GST fields when appending fuel entries
- Document column order in README

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b499cfdacc832581541cbc3345deaa