### PR TITLE
Parse station and GST

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -30,11 +30,11 @@ app.post('/entries', upload.single('photo'), async (req, res) => {
 
     await appendFuelRow({
       timestamp: new Date().toISOString(),
-      station: '',
+      station: parsed.station,
       litres: parsed.litres,
       price_per_litre: parsed.price_per_litre,
       total_cost: parsed.total_cost,
-      gst: '',
+      gst: parsed.gst,
       odometer,
       trip_odometer: tripOdometer
     });

--- a/backend/services/openai.js
+++ b/backend/services/openai.js
@@ -14,7 +14,7 @@ async function callModel(model, imageBase64) {
         content: [
           {
             type: 'input_text',
-            text: 'Extract litres, price per litre, and total cost from this fuel receipt image.'
+            text: 'Extract station name, litres, price per litre, total cost, and GST from this fuel receipt image.'
           },
           {
             type: 'input_image',
@@ -30,11 +30,13 @@ async function callModel(model, imageBase64) {
         schema: {
           type: 'object',
           properties: {
+            station: { type: 'string' },
             litres: { type: 'number' },
             price_per_litre: { type: 'number' },
-            total_cost: { type: 'number' }
+            total_cost: { type: 'number' },
+            gst: { type: 'number' }
           },
-          required: ['litres', 'price_per_litre', 'total_cost'],
+          required: ['station', 'litres', 'price_per_litre', 'total_cost', 'gst'],
           additionalProperties: false
         }
       }
@@ -48,11 +50,15 @@ async function parseReceipt(imagePath) {
     const response = await callModel('gpt-4.1-mini', imageBase64);
     const parsed = JSON.parse(response.output_text);
     if (
+      typeof parsed.station !== 'string' ||
       typeof parsed.litres !== 'number' ||
       typeof parsed.price_per_litre !== 'number' ||
-      typeof parsed.total_cost !== 'number'
+      typeof parsed.total_cost !== 'number' ||
+      typeof parsed.gst !== 'number'
     ) {
-      throw new Error('Parsing failed: missing numeric fields in model response.');
+      throw new Error(
+        'Parsing failed: missing required fields in model response.'
+      );
     }
     return parsed;
   } catch (error) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -53,9 +53,11 @@
         }
 
         result.innerHTML = `
+          <p>Station: ${data.station}</p>
           <p>Litres: ${data.litres}</p>
           <p>Price per litre: ${data.price_per_litre}</p>
           <p>Total cost: ${data.total_cost}</p>
+          <p>GST: ${data.gst}</p>
         `;
       } catch (err) {
         error.textContent = err.message;


### PR DESCRIPTION
## Summary
- expand OpenAI receipt parser to extract station name and GST along with fuel details
- persist parsed station and GST values to Google Sheets and surface them in the API response
- display station and GST in the frontend result output

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a05c6f0c8325b8ab0953fff6373a