### PR TITLE
Use data sheet for Google Sheets logging

### DIFF
--- a/backend/services/googleSheets.js
+++ b/backend/services/googleSheets.js
@@ -32,7 +32,7 @@ async function appendFuelRow({
 
   await sheets.spreadsheets.values.append({
     spreadsheetId: process.env.GOOGLE_SHEET_ID,
-    range: 'Sheet1!A:H',
+    range: 'data!A:H',
     valueInputOption: 'USER_ENTERED',
     requestBody: { values }
   });


### PR DESCRIPTION
## Summary
- point appendFuelRow to the `data` sheet instead of `Sheet1`

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a7f1253483259c73d6ef2d667c1f