### PR TITLE
Avoid displaying submitted data

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,7 +25,6 @@
       <button type="submit">Submit</button>
     </form>
     <div id="loading" class="loading">Submitting...</div>
-    <div id="result"></div>
   </div>
   <div id="notification" class="notification"></div>
   <script src="script.js"></script>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,6 +1,5 @@
 const form = document.getElementById('fuel-form');
 const loading = document.getElementById('loading');
-const result = document.getElementById('result');
 const notification = document.getElementById('notification');
 
 function showNotification(message, isError = false) {
@@ -12,7 +11,6 @@ function showNotification(message, isError = false) {
 
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
-  result.innerHTML = '';
   loading.style.display = 'block';
 
   const formData = new FormData(form);
@@ -28,13 +26,6 @@ form.addEventListener('submit', async (e) => {
       throw new Error(data.error || 'Request failed');
     }
 
-    result.innerHTML = `
-      <p>Station: ${data.station}</p>
-      <p>Litres: ${data.litres}</p>
-      <p>Price per litre: ${data.price_per_litre}</p>
-      <p>Total cost: ${data.total_cost}</p>
-      <p>GST: ${data.gst}</p>
-    `;
     showNotification('Entry submitted successfully');
   } catch (err) {
     showNotification(err.message, true);


### PR DESCRIPTION
## Summary
- Remove result container from frontend to stop showing parsed data after submission
- Simplify submit handler to only show success notifications without exposing returned data

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68b4aad44130832593ac01105b5a5f93