### PR TITLE
Limit daily uploads

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
+    "express-rate-limit": "^6.7.0",
     "googleapis": "^131.0.0",
     "multer": "^1.4.5-lts.1",
     "openai": "^4.0.0"


### PR DESCRIPTION
## Summary
- enforce a daily limit of five `/entries` submissions per client using `express-rate-limit`
- register `express-rate-limit` as a backend dependency

## Testing
- `npm test --prefix backend`
- `npm install --prefix backend express-rate-limit@^6.7.0` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d9bccc6c83259629987b930105ef