### PR TITLE
Add Home Assistant add-on for Fuel Logger

### DIFF
--- a/home_assistant/fuel_logger/Dockerfile
+++ b/home_assistant/fuel_logger/Dockerfile
@@ -1,0 +1,18 @@
+FROM ghcr.io/home-assistant/base:latest
+
+# Install Node.js
+RUN apt-get update \
+    && apt-get install -y nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY backend /app/backend
+COPY frontend /app/frontend
+RUN npm --prefix backend install \
+    && npm --prefix frontend install
+
+COPY run.sh /run.sh
+RUN chmod a+x /run.sh
+
+EXPOSE 3000
+CMD ["/run.sh"]

--- a/home_assistant/fuel_logger/README.md
+++ b/home_assistant/fuel_logger/README.md
@@ -1,0 +1,32 @@
+# Fuel Logger Home Assistant Add-on
+
+This add-on wraps the Fuel Logger application so it can run under Home Assistant.
+
+## Installation
+
+1. Copy the `home_assistant/fuel_logger` folder into your Home Assistant `addons` directory
+   or add this repository as a custom add-on repository.
+2. Refresh the add-on store and install **Fuel Logger**.
+
+## Configuration
+
+Set the following options in the add-on configuration:
+
+- `OPENAI_API_KEY` – API key from [OpenAI](https://platform.openai.com/).
+- `GOOGLE_CLIENT_EMAIL` – Service account client email from Google Cloud.
+- `GOOGLE_PRIVATE_KEY` – Private key for the service account.
+- `GOOGLE_SHEET_ID` – ID of the Google Sheet used to store entries.
+- `PORT` – Port for the backend (defaults to `3000`).
+
+## Obtaining API Keys
+
+1. **OpenAI**: Create an account at the OpenAI dashboard and generate an API key.
+2. **Google Sheets**: Create a service account in Google Cloud, enable the Sheets API, and
+   download the JSON credentials. Use the client email and private key values above. Share
+   the target spreadsheet with the service account email.
+
+## Usage
+
+After starting the add-on, the backend listens on port `3000`. The frontend files are
+served by the backend and can be accessed through Home Assistant at `http://<homeassistant>:3000/`.
+

--- a/home_assistant/fuel_logger/config.json
+++ b/home_assistant/fuel_logger/config.json
@@ -1,0 +1,19 @@
+{
+  "name": "Fuel Logger",
+  "version": "1.0.0",
+  "slug": "fuel_logger",
+  "description": "Log fuel entries via Google Sheets and OpenAI",
+  "arch": ["amd64", "armv7", "aarch64", "i386"],
+  "startup": "services",
+  "boot": "auto",
+  "ports": {
+    "3000/tcp": 3000
+  },
+  "schema": {
+    "OPENAI_API_KEY": "str",
+    "GOOGLE_CLIENT_EMAIL": "str",
+    "GOOGLE_PRIVATE_KEY": "str",
+    "GOOGLE_SHEET_ID": "str",
+    "PORT": "int"
+  }
+}

--- a/home_assistant/fuel_logger/run.sh
+++ b/home_assistant/fuel_logger/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/with-contenv bashio
+set -e
+
+export OPENAI_API_KEY="$(bashio::config 'OPENAI_API_KEY')"
+export GOOGLE_CLIENT_EMAIL="$(bashio::config 'GOOGLE_CLIENT_EMAIL')"
+export GOOGLE_PRIVATE_KEY="$(bashio::config 'GOOGLE_PRIVATE_KEY')"
+export GOOGLE_SHEET_ID="$(bashio::config 'GOOGLE_SHEET_ID')"
+export PORT="$(bashio::config 'PORT')"
+
+npm --prefix /app/backend start


### PR DESCRIPTION
## Summary
- add Home Assistant add-on scaffold for Fuel Logger
- expose configuration for API keys and port
- document installation and usage

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68b5dc1a06f883259f0dd22abc12a9f6