### PR TITLE
fix: use build arg for base image

### DIFF
--- a/fuel_logger/Dockerfile
+++ b/fuel_logger/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/home-assistant/base:latest
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:latest
+FROM ${BUILD_FROM}
 
 # Install Node.js
 RUN apt-get update \


### PR DESCRIPTION
## Summary
- enable architecture-specific base image via `BUILD_FROM`

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b5e04bbc548325a1e70122289e1e59