### PR TITLE
Specify add-on build context

### DIFF
--- a/fuel_logger/config.json
+++ b/fuel_logger/config.json
@@ -6,6 +6,10 @@
   "arch": ["amd64", "armv7", "aarch64", "i386"],
   "startup": "services",
   "boot": "auto",
+  "build": {
+    "context": "..",
+    "dockerfile": "fuel_logger/Dockerfile"
+  },
   "ports": {
     "3000/tcp": 3000
   },


### PR DESCRIPTION
## Summary
- specify the root context and Dockerfile for the Home Assistant fuel_logger add-on so Docker build can locate backend, frontend, and run script

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e0fe53e0832592c33aa7a3468d20