### PR TITLE
Fix add-on Dockerfile Node.js install and run script path

### DIFF
--- a/fuel_logger/Dockerfile
+++ b/fuel_logger/Dockerfile
@@ -2,9 +2,7 @@ ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:latest
 FROM ${BUILD_FROM}
 
 # Install Node.js
-RUN apt-get update \
-    && apt-get install -y nodejs npm \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache nodejs npm
 
 WORKDIR /app
 COPY backend /app/backend
@@ -12,7 +10,7 @@ COPY frontend /app/frontend
 RUN npm --prefix backend install \
     && npm --prefix frontend install
 
-COPY fuel_logger/run.sh /run.sh
+COPY run.sh /run.sh
 RUN chmod a+x /run.sh
 
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- Use `apk` instead of `apt-get` for Node.js installation in add-on Dockerfile
- Copy `run.sh` from add-on context

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e233253883259d35afa9e0152ef8