### PR TITLE
Ensure s6 init is PID 1 in Home Assistant image

### DIFF
--- a/fuel_logger/Dockerfile
+++ b/fuel_logger/Dockerfile
@@ -14,4 +14,5 @@ COPY run.sh /run.sh
 RUN chmod a+x /run.sh
 
 EXPOSE 3000
+ENTRYPOINT ["/init"]
 CMD ["/run.sh"]


### PR DESCRIPTION
## Summary
- Explicitly set `ENTRYPOINT ["/init"]` in the Home Assistant Dockerfile so s6-overlay runs as PID 1.

## Testing
- `npm test --prefix fuel_logger/backend`
- `npm test --prefix fuel_logger/frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4b9c6308325b5757d4f9346ad48