### PR TITLE
Ensure s6 init is PID 1 in Home Assistant image

### DIFF
--- a/fuel_logger/Dockerfile
+++ b/fuel_logger/Dockerfile
@@ -14,4 +14,5 @@ COPY run.sh /run.sh
 RUN chmod a+x /run.sh
 
 EXPOSE 3000
+ENTRYPOINT ["/init"]
 CMD ["/run.sh"]

--- a/fuel_logger/run.sh
+++ b/fuel_logger/run.sh
@@ -7,4 +7,4 @@ export GOOGLE_PRIVATE_KEY="$(bashio::config 'GOOGLE_PRIVATE_KEY')"
 export GOOGLE_SHEET_ID="$(bashio::config 'GOOGLE_SHEET_ID')"
 export PORT="$(bashio::config 'PORT')"
 
-npm --prefix /app/backend start
+exec npm --prefix /app/backend start


### PR DESCRIPTION
## Summary
- Explicitly run the backend with `exec` so the Node process becomes the container's main process under s6
- Keep the Home Assistant add-on Dockerfile using `/init` as the entrypoint

## Testing
- `npm test --prefix fuel_logger/backend`
- `npm test --prefix fuel_logger/frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4b9c6308325b5757d4f9346ad48