### PR TITLE
Expose Fuel Logger UI via Home Assistant sidebar panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Provide values for these options in the add-on configuration:
 
 Map port `3000` of the add-on to a host port such as `3000:3000` so the UI is accessible.
 
+### Home Assistant Sidebar Panel
+
+When the add-on is running, Home Assistant automatically exposes the Fuel Logger
+frontend through an ingress panel in the left sidebar. Click the **Fuel Logger**
+icon to open the UI directly inside Home Assistant. No additional configuration
+is required, but you may still map port `3000` if you want to access the UI
+outside of Home Assistant.
+
 ## Environment Variables
 
 Copy `.env.example` to `.env` and provide values for:

--- a/fuel_logger/README.md
+++ b/fuel_logger/README.md
@@ -28,5 +28,8 @@ Set the following options in the add-on configuration:
 ## Usage
 
 After starting the add-on, the backend listens on port `3000`. The frontend files are
-served by the backend and can be accessed through Home Assistant at `http://<homeassistant>:3000/`.
+served by the backend and are exposed inside Home Assistant via an ingress panel.
+The **Fuel Logger** icon appears in the sidebar; click it to open the UI within
+Home Assistant. You can still reach the interface externally at
+`http://<homeassistant>:3000/` if you mapped the port.
 

--- a/fuel_logger/config.json
+++ b/fuel_logger/config.json
@@ -14,6 +14,10 @@
   "ports": {
     "3000/tcp": 3000
   },
+  "ingress": true,
+  "ingress_port": 3000,
+  "panel_icon": "mdi:gas-station",
+  "panel_title": "Fuel Logger",
   "schema": {
     "OPENAI_API_KEY": "str",
     "GOOGLE_CLIENT_EMAIL": "str",


### PR DESCRIPTION
## Summary
- enable Home Assistant ingress and sidebar panel for the Fuel Logger add-on
- document how to access the UI through the new sidebar panel

## Testing
- `npm test --prefix fuel_logger/backend`
- `npm test --prefix fuel_logger/frontend`

------
https://chatgpt.com/codex/tasks/task_e_68b5e806663883258b55261c6b464002