### PR TITLE
Refactor HA add-on to use s6 service

### DIFF
--- a/fuel_logger/Dockerfile
+++ b/fuel_logger/Dockerfile
@@ -10,9 +10,6 @@ COPY frontend /app/frontend
 RUN npm --prefix backend install \
     && npm --prefix frontend install
 
-COPY run.sh /run.sh
-RUN chmod a+x /run.sh
+COPY rootfs /
 
 EXPOSE 3000
-ENTRYPOINT ["/init"]
-CMD ["/run.sh"]

--- a/fuel_logger/rootfs/etc/services.d/fuel-logger/run
+++ b/fuel_logger/rootfs/etc/services.d/fuel-logger/run
@@ -1,5 +1,7 @@
 #!/command/with-contenv bashio
-set -e
+# shellcheck shell=bash
+
+bashio::log.info "Starting Fuel Logger service"
 
 export OPENAI_API_KEY="$(bashio::config 'OPENAI_API_KEY')"
 export GOOGLE_CLIENT_EMAIL="$(bashio::config 'GOOGLE_CLIENT_EMAIL')"


### PR DESCRIPTION
## Summary
- Move backend startup into an s6 service under rootfs
- Simplify Dockerfile to copy rootfs and rely on /init entrypoint
- Remove redundant ENTRYPOINT to prevent s6-overlay PID1 errors

## Testing
- `npm test --prefix fuel_logger/backend`
- `npm test --prefix fuel_logger/frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b5e8db6e888325ab6e204762e76be9