### PR TITLE
Remove init flag from Home Assistant add-on

### DIFF
--- a/fuel_logger/config.json
+++ b/fuel_logger/config.json
@@ -6,7 +6,6 @@
   "arch": ["amd64", "armv7", "aarch64", "i386"],
   "startup": "services",
   "boot": "auto",
-  "init": true,
   "build": {
     "context": ".",
     "dockerfile": "Dockerfile"


### PR DESCRIPTION
## Summary
- remove `init` from Home Assistant add-on config to avoid s6-overlay PID 1 error

## Testing
- `npm --prefix fuel_logger/backend test`
- `npm --prefix fuel_logger/frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68b5fcaa0e6c8325b7caf93567d82723