### PR TITLE
Disable Docker init for Home Assistant add-on

### DIFF
--- a/fuel_logger/CHANGELOG.md
+++ b/fuel_logger/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.2
+- Explicitly disable Docker's `--init` in add-on config to avoid s6-overlay PID 1 error.
+
 ## 1.0.1
 - Use correct `with-contenv` path in startup script to ensure s6 remains PID 1.
 

--- a/fuel_logger/config.json
+++ b/fuel_logger/config.json
@@ -1,12 +1,12 @@
 {
   "name": "Fuel Logger",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "slug": "fuel_logger",
   "description": "Log fuel entries via Google Sheets and OpenAI",
   "arch": ["amd64", "armv7", "aarch64", "i386"],
   "startup": "services",
   "boot": "auto",
-  "init": true,
+  "init": false,
   "build": {
     "context": ".",
     "dockerfile": "Dockerfile"


### PR DESCRIPTION
## Summary
- explicitly set `init: false` in add-on config so s6-overlay runs as PID 1
- bump add-on version to 1.0.2 and document the fix

## Testing
- `npm --prefix fuel_logger/backend test`
- `npm --prefix fuel_logger/frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68b5fcaa0e6c8325b7caf93567d82723