### PR TITLE
fix: ensure service script shebang is first line

### DIFF
--- a/fuel_logger/CHANGELOG.md
+++ b/fuel_logger/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.3
+- Fix service script shebang to avoid s6-overlay PID 1 error.
+
 ## 1.0.2
 - Explicitly disable Docker's `--init` in add-on config to avoid s6-overlay PID 1 error.
 

--- a/fuel_logger/config.json
+++ b/fuel_logger/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Fuel Logger",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "slug": "fuel_logger",
   "description": "Log fuel entries via Google Sheets and OpenAI",
   "arch": ["amd64", "armv7", "aarch64", "i386"],

--- a/fuel_logger/rootfs/etc/services.d/fuel-logger/run
+++ b/fuel_logger/rootfs/etc/services.d/fuel-logger/run
@@ -1,4 +1,3 @@
-
 #!/usr/bin/with-contenv bashio
 # shellcheck shell=bash
 


### PR DESCRIPTION
## Summary
- fix service run script shebang so s6-overlay runs as pid 1
- bump add-on version to 1.0.3 and document change

## Testing
- `npm --prefix fuel_logger/backend test`

------
https://chatgpt.com/codex/tasks/task_e_68b6053532f48325b63241ba8378864c