### PR TITLE
Remove PORT option from add-on configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Provide values for these options in the add-on configuration:
 - `GOOGLE_CLIENT_EMAIL`
 - `GOOGLE_PRIVATE_KEY`
 - `GOOGLE_SHEET_ID`
-- `PORT` (defaults to `3000`)
 
 Map port `3000` of the add-on to a host port such as `3000:3000` so the UI is accessible.
 
@@ -45,7 +44,6 @@ Copy `.env.example` to `.env` and provide values for:
 - `GOOGLE_CLIENT_EMAIL` – service-account email for the Google Sheets API.
 - `GOOGLE_PRIVATE_KEY` – service-account private key (replace newline characters with `\n`).
 - `GOOGLE_SHEET_ID` – ID of the target Google Sheet.
-- `PORT` – (optional) port the server listens on; defaults to `3000`.
 
 ## Running the Server
 

--- a/fuel_logger/README.md
+++ b/fuel_logger/README.md
@@ -16,7 +16,6 @@ Set the following options in the add-on configuration:
 - `GOOGLE_CLIENT_EMAIL` – Service account client email from Google Cloud.
 - `GOOGLE_PRIVATE_KEY` – Private key for the service account.
 - `GOOGLE_SHEET_ID` – ID of the Google Sheet used to store entries.
-- `PORT` – Port for the backend (defaults to `3000`).
 
 ## Obtaining API Keys
 

--- a/fuel_logger/config.json
+++ b/fuel_logger/config.json
@@ -23,7 +23,6 @@
     "OPENAI_API_KEY": "str",
     "GOOGLE_CLIENT_EMAIL": "str",
     "GOOGLE_PRIVATE_KEY": "str",
-    "GOOGLE_SHEET_ID": "str",
-    "PORT": "int"
+    "GOOGLE_SHEET_ID": "str"
   }
 }

--- a/fuel_logger/rootfs/etc/services.d/fuel-logger/run
+++ b/fuel_logger/rootfs/etc/services.d/fuel-logger/run
@@ -7,6 +7,5 @@ export OPENAI_API_KEY="$(bashio::config 'OPENAI_API_KEY')"
 export GOOGLE_CLIENT_EMAIL="$(bashio::config 'GOOGLE_CLIENT_EMAIL')"
 export GOOGLE_PRIVATE_KEY="$(bashio::config 'GOOGLE_PRIVATE_KEY')"
 export GOOGLE_SHEET_ID="$(bashio::config 'GOOGLE_SHEET_ID')"
-export PORT="$(bashio::config 'PORT')"
 
 exec npm --prefix /app/backend start


### PR DESCRIPTION
## Summary
- fix Home Assistant add-on port by removing configurable PORT option
- update run script and documentation to rely on fixed internal port 3000

## Testing
- `npm test --prefix fuel_logger/backend`

------
https://chatgpt.com/codex/tasks/task_e_68b6104e3cdc83258af580a7ef64b145