### PR TITLE
Set backend port from addon config

### DIFF
--- a/fuel_logger/rootfs/etc/services.d/fuel-logger/run
+++ b/fuel_logger/rootfs/etc/services.d/fuel-logger/run
@@ -8,4 +8,9 @@ export GOOGLE_CLIENT_EMAIL="$(bashio::config 'GOOGLE_CLIENT_EMAIL')"
 export GOOGLE_PRIVATE_KEY="$(bashio::config 'GOOGLE_PRIVATE_KEY')"
 export GOOGLE_SHEET_ID="$(bashio::config 'GOOGLE_SHEET_ID')"
 
+# Respect the configured port from the add-on options
+PORT="$(bashio::addon.port 3000)"
+export PORT
+bashio::log.info "Listening on port ${PORT}"
+
 exec npm --prefix /app/backend start


### PR DESCRIPTION
## Summary
- Export PORT from add-on run script so backend uses configured port

## Testing
- `npm test --prefix fuel_logger/backend`

------
https://chatgpt.com/codex/tasks/task_e_68b611e65f708325a11f60f99f384114