### PR TITLE
Fix port handling for Fuel Logger add-on

### DIFF
--- a/fuel_logger/CHANGELOG.md
+++ b/fuel_logger/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.4
+- Ensure the service listens on the correct internal port to prevent Bad Gateway errors when the mapped host port changes.
+
 ## 1.0.3
 - Fix service script shebang to avoid s6-overlay PID 1 error.
 

--- a/fuel_logger/rootfs/etc/services.d/fuel-logger/run
+++ b/fuel_logger/rootfs/etc/services.d/fuel-logger/run
@@ -8,8 +8,13 @@ export GOOGLE_CLIENT_EMAIL="$(bashio::config 'GOOGLE_CLIENT_EMAIL')"
 export GOOGLE_PRIVATE_KEY="$(bashio::config 'GOOGLE_PRIVATE_KEY')"
 export GOOGLE_SHEET_ID="$(bashio::config 'GOOGLE_SHEET_ID')"
 
-# Respect the configured port from the add-on options
-PORT="$(bashio::addon.port 3000)"
+# Determine the internal port used by the backend. Using the ingress port
+# ensures the service keeps listening on the container's port even when the
+# mapped host port changes, avoiding Bad Gateway errors.
+PORT="$(bashio::addon.ingress_port 2>/dev/null)"
+if ! bashio::var.has_value "${PORT}"; then
+    PORT="3000"
+fi
 export PORT
 bashio::log.info "Listening on port ${PORT}"
 


### PR DESCRIPTION
## Summary
- ensure backend uses ingress port instead of mapped host port
- update changelog for 1.0.4

## Testing
- `npm test --prefix fuel_logger/backend`
- `npm test --prefix fuel_logger/frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b613277ef883258aaf1df7d37e7a97