### PR TITLE
Switch to port 3001

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN npm install --prefix fuel_logger/frontend
 # Copy the rest of the code
 COPY . .
 
-EXPOSE 3000
+EXPOSE 3001
 CMD ["npm", "--prefix", "fuel_logger/backend", "start"]

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ Provide values for these options in the add-on configuration:
 - `GOOGLE_PRIVATE_KEY`
 - `GOOGLE_SHEET_ID`
 
-Map port `3000` of the add-on to a host port such as `3000:3000` so the UI is accessible.
+Map port `3001` of the add-on to a host port such as `3001:3001` so the UI is accessible.
 
 ### Home Assistant Sidebar Panel
 
 When the add-on is running, Home Assistant automatically exposes the Fuel Logger
 frontend through an ingress panel in the left sidebar. Click the **Fuel Logger**
 icon to open the UI directly inside Home Assistant. No additional configuration
-is required, but you may still map port `3000` if you want to access the UI
+is required, but you may still map port `3001` if you want to access the UI
 outside of Home Assistant.
 
 ## Environment Variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,4 @@ services:
     build: .
     command: npm --prefix fuel_logger/backend start
     ports:
-      - "3000:3000"
+      - "3001:3001"

--- a/fuel_logger/Dockerfile
+++ b/fuel_logger/Dockerfile
@@ -12,4 +12,4 @@ RUN npm --prefix backend install \
 
 COPY rootfs /
 
-EXPOSE 3000
+EXPOSE 3001

--- a/fuel_logger/README.md
+++ b/fuel_logger/README.md
@@ -26,9 +26,9 @@ Set the following options in the add-on configuration:
 
 ## Usage
 
-After starting the add-on, the backend listens on port `3000`. The frontend files are
+After starting the add-on, the backend listens on port `3001`. The frontend files are
 served by the backend and are exposed inside Home Assistant via an ingress panel.
 The **Fuel Logger** icon appears in the sidebar; click it to open the UI within
 Home Assistant. You can still reach the interface externally at
-`http://<homeassistant>:3000/` if you mapped the port.
+`http://<homeassistant>:3001/` if you mapped the port.
 

--- a/fuel_logger/backend/index.js
+++ b/fuel_logger/backend/index.js
@@ -12,7 +12,7 @@ const { parseReceipt } = require('./services/openai');
 const { appendFuelRow } = require('./services/googleSheets');
 
 const app = express();
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 3001;
 
 // Serve static frontend files
 app.use(express.static(path.join(__dirname, '../frontend')));

--- a/fuel_logger/config.json
+++ b/fuel_logger/config.json
@@ -13,10 +13,10 @@
     "dockerfile": "Dockerfile"
   },
   "ports": {
-    "3000/tcp": 3000
+    "3001/tcp": 3001
   },
   "ingress": true,
-  "ingress_port": 3000,
+  "ingress_port": 3001,
   "panel_icon": "mdi:gas-station",
   "panel_title": "Fuel Logger",
   "schema": {

--- a/fuel_logger/rootfs/etc/services.d/fuel-logger/run
+++ b/fuel_logger/rootfs/etc/services.d/fuel-logger/run
@@ -13,7 +13,7 @@ export GOOGLE_SHEET_ID="$(bashio::config 'GOOGLE_SHEET_ID')"
 # mapped host port changes, avoiding Bad Gateway errors.
 PORT="$(bashio::addon.ingress_port 2>/dev/null)"
 if ! bashio::var.has_value "${PORT}"; then
-    PORT="3000"
+    PORT="3001"
 fi
 export PORT
 bashio::log.info "Listening on port ${PORT}"


### PR DESCRIPTION
## Summary
- serve the Fuel Logger backend on port 3001 by default
- expose port 3001 in Dockerfiles and docker-compose setup
- update Home Assistant add-on configuration and documentation to reflect port 3001

## Testing
- `npm --prefix fuel_logger/backend test`
- `npm --prefix fuel_logger/frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68b61480539c83258d217ec9bbc941e3