### PR TITLE
Handle trailing text when parsing model output

### DIFF
--- a/fuel_logger/backend/index.js
+++ b/fuel_logger/backend/index.js
@@ -30,7 +30,7 @@ const dailyLimiter = rateLimit({
 });
 
 // Handle form submissions
-app.post('/entries', dailyLimiter, upload.single('photo'), async (req, res) => {
+  app.post('/entries', dailyLimiter, upload.single('photo'), async (req, res) => {
   const { odometer, tripOdometer } = req.body;
   const photo = req.file ? req.file.filename : null;
 
@@ -55,10 +55,11 @@ app.post('/entries', dailyLimiter, upload.single('photo'), async (req, res) => {
       photo,
       ...parsed
     });
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-});
+    } catch (error) {
+      console.error('[POST /entries] Error handling submission:', error);
+      res.status(500).json({ error: error.message });
+    }
+  });
 
 app.listen(PORT, () => {
   console.log(`Backend server listening on port ${PORT}`);

--- a/fuel_logger/backend/services/openai.js
+++ b/fuel_logger/backend/services/openai.js
@@ -54,26 +54,83 @@ async function callModel(model, imageBase64) {
         }
       }
     }
-  });
+    });
+}
+
+// Extract the first JSON object found in a string. This guards against code
+// fences or extra commentary being included in the model response.
+function extractFirstJsonObject(text) {
+  // If the model wrapped the payload in a code fence (```json ... ```), prefer
+  // the fenced content as our starting point.
+  const fenceMatch = text.match(/```(?:json)?\n([\s\S]*?)```/i);
+  if (fenceMatch) {
+    const candidate = findBalancedJson(fenceMatch[1]);
+    if (candidate) return candidate;
+  }
+  return findBalancedJson(text);
+}
+
+// Scan for the first balanced set of braces in a string and return that
+// substring. Returns null if no complete object is found.
+function findBalancedJson(str) {
+  const start = str.indexOf('{');
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  for (let i = start; i < str.length; i++) {
+    const char = str[i];
+    if (char === '"' && str[i - 1] !== '\\') {
+      inString = !inString;
+    } else if (!inString) {
+      if (char === '{') {
+        depth++;
+      } else if (char === '}') {
+        depth--;
+        if (depth === 0) {
+          return str.slice(start, i + 1);
+        }
+      }
+    }
+  }
+  return null;
 }
 
 async function parseReceipt(imagePath) {
   try {
+    if (!fs.existsSync(imagePath)) {
+      console.error(`[parseReceipt] Image file not found: ${imagePath}`);
+      throw new Error(`Image not found at ${imagePath}`);
+    }
+
+    console.log(`[parseReceipt] Reading image from ${imagePath}`);
     const imageBase64 = fs.readFileSync(imagePath, { encoding: 'base64' });
+
+    console.log('[parseReceipt] Sending image to model');
     const response = await callModel('gpt-4.1-mini', imageBase64);
+
+    const text = (response && response.output_text ? response.output_text : '')
+      .trim();
+    console.log('[parseReceipt] Raw model output:', text);
+
     // The model should return pure JSON thanks to the json_schema option, but
     // in practice we occasionally see additional text or code fences wrapped
     // around the payload. Attempt to extract the first JSON object found in the
     // response before parsing so that trailing explanations do not cause a
     // SyntaxError such as "Unexpected non-whitespace character after JSON".
-    const text = response.output_text.trim();
-    const start = text.indexOf('{');
-    const end = text.lastIndexOf('}');
-    if (start === -1 || end === -1 || end <= start) {
+    const json = extractFirstJsonObject(text);
+    if (!json) {
+      console.error('[parseReceipt] Model response did not contain JSON:', text);
       throw new Error('Model response did not contain JSON');
     }
-    const json = text.slice(start, end + 1);
-    const parsed = JSON.parse(json);
+
+    let parsed;
+    try {
+      parsed = JSON.parse(json);
+    } catch (parseError) {
+      console.error('[parseReceipt] Failed to parse JSON:', parseError, json);
+      throw new Error(`Invalid JSON from model: ${parseError.message}`);
+    }
+
     if (
       typeof parsed.station !== 'string' ||
       typeof parsed.litres !== 'number' ||
@@ -81,12 +138,16 @@ async function parseReceipt(imagePath) {
       typeof parsed.total_cost !== 'number' ||
       typeof parsed.gst !== 'number'
     ) {
+      console.error('[parseReceipt] Missing required fields:', parsed);
       throw new Error(
         'Parsing failed: missing required fields in model response.'
       );
     }
+
+    console.log('[parseReceipt] Successfully parsed receipt:', parsed);
     return parsed;
   } catch (error) {
+    console.error('[parseReceipt] Error:', error);
     throw new Error(`Failed to parse receipt: ${error.message}`);
   }
 }


### PR DESCRIPTION
## Summary
- Strip code fences and find the first balanced JSON object before parsing, logging raw model output for easier debugging
- Surface backend errors in Home Assistant logs by reporting failures in the `/entries` handler

## Testing
- `npm test` (backend)
- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68b6160402b483259fc38063763cd10f