### PR TITLE
fix: close JSON extraction loop

### DIFF
--- a/fuel_logger/backend/services/openai.js
+++ b/fuel_logger/backend/services/openai.js
@@ -89,6 +89,7 @@ function findBalancedJson(str) {
         depth--;
         if (depth === 0) {
           return str.slice(start, i + 1);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- fix missing closing braces in `findBalancedJson` to avoid syntax error

## Testing
- `npm test`
- `node -e "require('./fuel_logger/backend/services/openai'); console.log('openai service loaded')"`


------
https://chatgpt.com/codex/tasks/task_e_68b61b8aabb48325b531f9b13f3b71de