### PR TITLE
Fix fetch path for entries endpoint in frontend

### DIFF
--- a/fuel_logger/frontend/script.js
+++ b/fuel_logger/frontend/script.js
@@ -16,7 +16,7 @@ form.addEventListener('submit', async (e) => {
   const formData = new FormData(form);
 
   try {
-    const response = await fetch('/entries', {
+    const response = await fetch('entries', {
       method: 'POST',
       body: formData,
     });


### PR DESCRIPTION
## Summary
- Use relative path for entries POST to work with Home Assistant ingress

## Testing
- `cd fuel_logger/backend && npm test`
- `cd fuel_logger/frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b61cc7d81c83259d8fbfc34f2bf333