### PR TITLE
feat: add camera capture and auto upload

### DIFF
--- a/fuel_logger/frontend/index.html
+++ b/fuel_logger/frontend/index.html
@@ -19,8 +19,8 @@
         <input type="number" id="tripOdometer" name="tripOdometer" required />
       </div>
       <div>
-        <label for="photo">Photo:</label>
-        <input type="file" id="photo" name="photo" accept="image/*" />
+        <button type="button" id="take-photo">Take Photo</button>
+        <input type="file" id="photo" name="photo" accept="image/*" capture="environment" hidden />
       </div>
       <button type="submit">Submit</button>
     </form>

--- a/fuel_logger/frontend/script.js
+++ b/fuel_logger/frontend/script.js
@@ -1,6 +1,8 @@
 const form = document.getElementById('fuel-form');
 const loading = document.getElementById('loading');
 const notification = document.getElementById('notification');
+const photoInput = document.getElementById('photo');
+const takePhotoButton = document.getElementById('take-photo');
 
 function showNotification(message, isError = false) {
   notification.textContent = message;
@@ -9,7 +11,7 @@ function showNotification(message, isError = false) {
   setTimeout(() => notification.classList.remove('show'), 3000);
 }
 
-form.addEventListener('submit', async (e) => {
+async function handleSubmit(e) {
   e.preventDefault();
   loading.style.display = 'block';
 
@@ -27,9 +29,22 @@ form.addEventListener('submit', async (e) => {
     }
 
     showNotification('Entry submitted successfully');
+    form.reset();
   } catch (err) {
     showNotification(err.message, true);
   } finally {
     loading.style.display = 'none';
+  }
+}
+
+form.addEventListener('submit', handleSubmit);
+
+takePhotoButton.addEventListener('click', () => {
+  photoInput.click();
+});
+
+photoInput.addEventListener('change', () => {
+  if (photoInput.files.length > 0) {
+    form.requestSubmit();
   }
 });


### PR DESCRIPTION
## Summary
- allow capturing photos directly via device camera
- automatically submit form after photo is taken

## Testing
- `npm test --prefix fuel_logger/frontend`
- `npm test --prefix fuel_logger/backend`


------
https://chatgpt.com/codex/tasks/task_e_68b84e7bd04c83258258c585761090ca