### PR TITLE
Ensure mobile camera stream plays automatically

### DIFF
--- a/fuel_logger/frontend/index.html
+++ b/fuel_logger/frontend/index.html
@@ -28,7 +28,7 @@
     <div id="loading" class="loading">Submitting...</div>
   </div>
   <div id="camera-modal" class="camera-modal">
-    <video id="camera-stream" autoplay></video>
+    <video id="camera-stream" autoplay playsinline muted></video>
     <button type="button" id="capture-btn">Capture</button>
     <button type="button" id="close-camera">Cancel</button>
   </div>

--- a/fuel_logger/frontend/script.js
+++ b/fuel_logger/frontend/script.js
@@ -62,6 +62,7 @@ takePhotoButton.addEventListener('click', async () => {
       audio: false,
     });
     cameraStream.srcObject = stream;
+    await cameraStream.play();
     cameraModal.classList.add('show');
   } catch (err) {
     showNotification('Camera access denied', true);


### PR DESCRIPTION
## Summary
- Start camera stream playback after setting the video source
- Allow inline, muted video playback for mobile browsers

## Testing
- `npm test` (frontend)
- `npm test` (backend)

------
https://chatgpt.com/codex/tasks/task_e_68b854e1aba88325817efb3a7131e18d