### PR TITLE
Expose Fuel Logger UI without ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,25 @@ Provide values for these options in the add-on configuration:
 - `GOOGLE_SHEET_ID`
 
 Map port `3001` of the add-on to a host port such as `3001:3001` so the UI is accessible.
+The UI is then available directly at `http://<homeassistant>:3001/` and is no
+longer embedded via Home Assistant's ingress system.
 
-### Home Assistant Sidebar Panel
+### Optional Home Assistant Panel
 
-When the add-on is running, Home Assistant automatically exposes the Fuel Logger
-frontend through an ingress panel in the left sidebar. Click the **Fuel Logger**
-icon to open the UI directly inside Home Assistant. No additional configuration
-is required, but you may still map port `3001` if you want to access the UI
-outside of Home Assistant.
+If you still want a sidebar entry, create a [panel iframe](https://www.home-assistant.io/integrations/panel_iframe/)
+in your Home Assistant configuration:
+
+```yaml
+panel_iframe:
+  fuel_logger:
+    title: "Fuel Logger"
+    icon: mdi:gas-station
+    url: "http://<homeassistant>:3001"
+    allow: "camera; microphone"
+```
+
+The `allow` attribute ensures the page can access the camera and microphone via
+`getUserMedia`.
 
 ## Environment Variables
 

--- a/fuel_logger/CHANGELOG.md
+++ b/fuel_logger/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0
+- Disable Home Assistant ingress and expose the UI directly on port `3001`.
+- Document how to embed the interface with camera and microphone permissions.
+
 ## 1.0.4
 - Ensure the service listens on the correct internal port to prevent Bad Gateway errors when the mapped host port changes.
 

--- a/fuel_logger/README.md
+++ b/fuel_logger/README.md
@@ -26,9 +26,11 @@ Set the following options in the add-on configuration:
 
 ## Usage
 
-After starting the add-on, the backend listens on port `3001`. The frontend files are
-served by the backend and are exposed inside Home Assistant via an ingress panel.
-The **Fuel Logger** icon appears in the sidebar; click it to open the UI within
-Home Assistant. You can still reach the interface externally at
-`http://<homeassistant>:3001/` if you mapped the port.
+After starting the add-on, the backend listens on port `3001`. The UI is available
+directly at `http://<homeassistant>:3001/` and is not embedded via Home Assistant's
+ingress system.
+
+To add a sidebar entry, create a [panel iframe](https://www.home-assistant.io/integrations/panel_iframe/)
+in your Home Assistant configuration and include `allow: "camera; microphone"` so the
+interface can access the device camera without prompting the user.
 

--- a/fuel_logger/config.json
+++ b/fuel_logger/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Fuel Logger",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "slug": "fuel_logger",
   "description": "Log fuel entries via Google Sheets and OpenAI",
   "arch": ["amd64", "armv7", "aarch64", "i386"],
@@ -15,10 +15,7 @@
   "ports": {
     "3001/tcp": 3001
   },
-  "ingress": true,
-  "ingress_port": 3001,
-  "panel_icon": "mdi:gas-station",
-  "panel_title": "Fuel Logger",
+  "webui": "http://[HOST]:[PORT:3001]",
   "schema": {
     "OPENAI_API_KEY": "str",
     "GOOGLE_CLIENT_EMAIL": "str",

--- a/fuel_logger/rootfs/etc/services.d/fuel-logger/run
+++ b/fuel_logger/rootfs/etc/services.d/fuel-logger/run
@@ -8,14 +8,8 @@ export GOOGLE_CLIENT_EMAIL="$(bashio::config 'GOOGLE_CLIENT_EMAIL')"
 export GOOGLE_PRIVATE_KEY="$(bashio::config 'GOOGLE_PRIVATE_KEY')"
 export GOOGLE_SHEET_ID="$(bashio::config 'GOOGLE_SHEET_ID')"
 
-# Determine the internal port used by the backend. Using the ingress port
-# ensures the service keeps listening on the container's port even when the
-# mapped host port changes, avoiding Bad Gateway errors.
-PORT="$(bashio::addon.ingress_port 2>/dev/null)"
-if ! bashio::var.has_value "${PORT}"; then
-    PORT="3001"
-fi
-export PORT
+# Expose the backend on a fixed port so it can be accessed directly
+export PORT="3001"
 bashio::log.info "Listening on port ${PORT}"
 
 exec npm --prefix /app/backend start


### PR DESCRIPTION
## Summary
- Disable Home Assistant ingress and serve the UI directly on port 3001
- Simplify startup script and document optional panel iframe with camera permissions

## Testing
- `npm test --prefix fuel_logger/backend`
- `npm test --prefix fuel_logger/frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b857a62c508325ae95e4a677403cb9