### PR TITLE
Fix backend port detection after config revert

### DIFF
--- a/fuel_logger/rootfs/etc/services.d/fuel-logger/run
+++ b/fuel_logger/rootfs/etc/services.d/fuel-logger/run
@@ -8,10 +8,11 @@ export GOOGLE_CLIENT_EMAIL="$(bashio::config 'GOOGLE_CLIENT_EMAIL')"
 export GOOGLE_PRIVATE_KEY="$(bashio::config 'GOOGLE_PRIVATE_KEY')"
 export GOOGLE_SHEET_ID="$(bashio::config 'GOOGLE_SHEET_ID')"
 
-# Determine the internal port used by the backend. Using the ingress port
-# ensures the service keeps listening on the container's port even when the
-# mapped host port changes, avoiding Bad Gateway errors.
-PORT="$(bashio::addon.ingress_port 2>/dev/null)"
+# Determine the port: prefer configured network port, then ingress, else default
+PORT="$(bashio::addon.port 3001/tcp 2>/dev/null)"
+if ! bashio::var.has_value "${PORT}"; then
+    PORT="$(bashio::addon.ingress_port 2>/dev/null)"
+fi
 if ! bashio::var.has_value "${PORT}"; then
     PORT="3001"
 fi


### PR DESCRIPTION
## Summary
- Ensure Fuel Logger service listens on the configured network port with a sane fallback

## Testing
- `npm --prefix fuel_logger/backend test` *(fails: npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b85cfb4cf08325a7ecd42496e61b03